### PR TITLE
Added CSS theme change behavior in theme.js

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <link rel="stylesheet" href="https://bootswatch.com/5/vapor/bootstrap.min.css">
+    <link id="css-theme" rel="stylesheet" href="https://bootswatch.com/5/vapor/bootstrap.min.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
             crossorigin="anonymous"></script>

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,28 @@
+/*
+    Exports: THEMES (object), setTheme (function)
+    The THEMES object can be externally viewed to select a theme. One of its
+    keys (not properties - to simplify external selection code) can then be
+    provided to setTheme to replace the page's stylesheet.
+*/
+
+// These objects are used only as immutable dictionaries, and property naming
+// conventions are ignored to simplify the code that sets the theme.
+const THEMES_DICT = Object.freeze({
+    "Dark 1": ["Vapor", "https://bootswatch.com/5/vapor/bootstrap.min.css"],
+    "Dark 2": ["Darkly", "https://bootswatch.com/5/darkly/bootstrap.min.css"],
+    "Light 1": ["Pulse", "https://bootswatch.com/5/pulse/bootstrap.min.css"],
+    "Light 2": ["Sandstone", "https://bootswatch.com/5/sandstone/bootstrap.min.css"],
+});
+export const THEMES = Object.freeze(Object.fromEntries(
+    Object.entries(THEMES_DICT).map(
+        ([label, [name, _]]) => [label, name]
+    ) // Avoiding a list here makes THEMES truly immutable
+));
+
+export const setTheme = (theme) => {console.log(theme);console.log(THEMES_DICT)
+    if (!Object.keys(THEMES_DICT).includes(theme))
+        return false;
+
+    document.getElementById("css-theme").href = THEMES_DICT[theme][1];
+    return true;
+}

--- a/src/theme.js
+++ b/src/theme.js
@@ -5,7 +5,7 @@
     provided to setTheme to replace the page's stylesheet.
 */
 
-// These objects are used only as immutable dictionaries, and property naming
+// These objects are used only as unchanging dictionaries, and property naming
 // conventions are ignored to simplify the code that sets the theme.
 const THEMES_DICT = Object.freeze({
     "Dark 1": ["Vapor", "https://bootswatch.com/5/vapor/bootstrap.min.css"],
@@ -16,10 +16,10 @@ const THEMES_DICT = Object.freeze({
 export const THEMES = Object.freeze(Object.fromEntries(
     Object.entries(THEMES_DICT).map(
         ([label, [name, _]]) => [label, name]
-    ) // Avoiding a list here makes THEMES truly immutable
+    ) // Avoiding a list here makes THEMES truly immutable and safe to export
 ));
 
-export const setTheme = (theme) => {console.log(theme);console.log(THEMES_DICT)
+export const setTheme = (theme) => {
     if (!Object.keys(THEMES_DICT).includes(theme))
         return false;
 


### PR DESCRIPTION
Add `import { THEMES, setTheme } from './theme';` to the start of a JS file to access the theme changing behavior.

The available themes can be retrieved from the THEMES object, and any of the THEMES object's keys ("Dark 1", "Dark 2", "Light 1", "Light 2") can be sent to the setTheme function to update the theme. setTheme returns a boolean indicating whether the specified theme exists.